### PR TITLE
Fix whiteboard display issue

### DIFF
--- a/Tool/src/app/layout.tsx
+++ b/Tool/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
+import '@excalidraw/excalidraw/index.css';
 import { Navigation } from '@/components/navigation';
 import { ThemeProvider } from '@/components/theme-provider';
 import { LanguageProvider } from '@/components/language-provider';


### PR DESCRIPTION
Add Excalidraw CSS import to fix whiteboard tool display issues.

The whiteboard tool was not displaying correctly due to missing Excalidraw styles. Importing `@excalidraw/excalidraw/index.css` in the global layout ensures the component styles are correctly loaded.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec813570-31c6-4a5f-9be9-22d1f8047c61">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ec813570-31c6-4a5f-9be9-22d1f8047c61">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

